### PR TITLE
Let the delegate know if the page was selected or deselected in selectedPageAtIndex:

### DIFF
--- a/Classes/SSStackedPageView.h
+++ b/Classes/SSStackedPageView.h
@@ -31,6 +31,7 @@
 - (NSInteger)numberOfPagesForStackView:(SSStackedPageView *)stackView;
 
 ///handler for when a page is selected
-- (void)stackView:(SSStackedPageView *)stackView selectedPageAtIndex:(NSInteger) index;
+// selected - if false it means the card was deselected
+- (void)stackView:(SSStackedPageView *)stackView selectedPageAtIndex:(NSInteger)index selected:(BOOL)selected;
 
 @end

--- a/Classes/SSStackedPageView.m
+++ b/Classes/SSStackedPageView.m
@@ -124,6 +124,15 @@
     }
 }
 
+-(void)setSelectedPageIndex:(NSInteger)selectedPageIndex
+{
+    [self.delegate stackView:self
+         selectedPageAtIndex:selectedPageIndex >= 0 ? selectedPageIndex : self.selectedPageIndex
+                    selected:selectedPageIndex >= 0];
+    
+    _selectedPageIndex = selectedPageIndex;
+}
+
 - (void)resetPages
 {
     NSInteger start = self.visiblePages.location;
@@ -316,7 +325,7 @@
         pageTouchFrame.size.height = PAGE_PEAK;
     }
     [self selectPageAtIndex:index];
-    [self.delegate stackView:self selectedPageAtIndex:index];
+    
 }
 
 - (void)panned:(UIPanGestureRecognizer*)recognizer
@@ -337,7 +346,6 @@
         if (self.trackedTranslation < -PAGE_PEAK) {
             NSInteger pageIndex = [self.pages indexOfObject:page];
             [self selectPageAtIndex:pageIndex];
-            [self.delegate stackView:self selectedPageAtIndex:pageIndex];
         } else {
             self.selectedPageIndex = -1;
             [self resetPages];

--- a/Example/SSStackView/SSStackedPageView.h
+++ b/Example/SSStackView/SSStackedPageView.h
@@ -31,6 +31,8 @@
 - (NSInteger)numberOfPagesForStackView:(SSStackedPageView *)stackView;
 
 ///handler for when a page is selected
-- (void)stackView:(SSStackedPageView *)stackView selectedPageAtIndex:(NSInteger) index;
+// selected - if false it means the card was deselected
+- (void)stackView:(SSStackedPageView *)stackView selectedPageAtIndex:(NSInteger)index selected:(BOOL)selected;
+
 
 @end

--- a/Example/SSStackView/SSStackedPageView.m
+++ b/Example/SSStackView/SSStackedPageView.m
@@ -124,6 +124,15 @@
     }
 }
 
+-(void)setSelectedPageIndex:(NSInteger)selectedPageIndex
+{
+    [self.delegate stackView:self
+         selectedPageAtIndex:selectedPageIndex >= 0 ? selectedPageIndex : self.selectedPageIndex
+                    selected:selectedPageIndex >= 0];
+    
+    _selectedPageIndex = selectedPageIndex;
+}
+
 - (void)resetPages
 {
     NSInteger start = self.visiblePages.location;
@@ -315,7 +324,7 @@
         pageTouchFrame.size.height = PAGE_PEAK;
     }
     [self selectPageAtIndex:index];
-    [self.delegate stackView:self selectedPageAtIndex:index];
+    
 }
 
 - (void)panned:(UIPanGestureRecognizer*)recognizer
@@ -336,7 +345,6 @@
         if (self.trackedTranslation < -PAGE_PEAK) {
             NSInteger pageIndex = [self.pages indexOfObject:page];
             [self selectPageAtIndex:pageIndex];
-            [self.delegate stackView:self selectedPageAtIndex:pageIndex];
         } else {
             self.selectedPageIndex = -1;
             [self resetPages];

--- a/Example/SSStackView/ViewController.m
+++ b/Example/SSStackView/ViewController.m
@@ -55,9 +55,9 @@
     return [self.views count];
 }
 
-- (void)stackView:(SSStackedPageView *)stackView selectedPageAtIndex:(NSInteger) index
+- (void)stackView:(SSStackedPageView *)stackView selectedPageAtIndex:(NSInteger) index selected:(BOOL)selected
 {
-    NSLog(@"selected page: %i",(int)index);
+    NSLog(@"%@ page: %i",selected ? @"selected" : @"deselected", (int)index);
 }
 
 


### PR DESCRIPTION
Currently when the delegate method selectedPageAtIndex: is called it is hard to tell if that page was actually selected or deselected. This small change adds an additional 'selected' boolean to make that obvious.
